### PR TITLE
Update view.js

### DIFF
--- a/DemoVault/Dashboard.md
+++ b/DemoVault/Dashboard.md
@@ -12,7 +12,7 @@ TABLE WITHOUT ID
 	(link(file.path, alias)) as title,
 	Bar
 FROM #goal
-WHERE number(Progress) != number(Target)
+WHERE type != "Archive"
 SORT Type DESC
 ```
 

--- a/DemoVault/views/total-progress-bar/view.js
+++ b/DemoVault/views/total-progress-bar/view.js
@@ -32,8 +32,8 @@ Object.assign(containerEl.style, {
     "justify-content": "center",
 });
 
-const max = Target || 0;
-const value = Progress || 0;
+const max = 100 || 0;
+const value = Math.round((Progress/Target)*100) || 0; 
 const percent = Math.round((value / max) * 100) || 0;
 
 const progressBar = containerEl.createEl("progress");


### PR DESCRIPTION
Progress bars can have their color changed via CSS based on ```value``` as a portion of 100%, but currently this view calculates a ```value``` is calculated as a non percentage ```progress``` of a ```target```. The bar length is correct, but the ```value``` will not reflect the percentage complete.

Example: progress 32, target 36 = 60% complete. the HTML is rendered as ```value="32" max="36"```

The CSS will style this as 32% complete. It does it this way in demo vault now and results in inconsistent colors used. So much so that two progress bars which both actually = 33% complete can be colored differently if the ```value``` of one is "10" and one is "50".

![Snag_ed3d85](https://github.com/chhoumann/DemoVault/assets/4020954/b97f720e-7a76-49af-a2ee-4fe5d95aa617)

My change updates the calculation to force the max to 100 and set the value to the percentage of ```progress``` as it relates to ```target```.